### PR TITLE
HTTPSClient error "Connection reset by peer" when making request

### DIFF
--- a/Source/TCPConnection.swift
+++ b/Source/TCPConnection.swift
@@ -90,7 +90,7 @@ public final class TCPConnection: Connection {
           do {
             try ensureLastOperationSucceeded()
           } catch SystemError.connectionResetByPeer {
-            throw StreamError.closedStream(data:Data())
+            throw StreamError.closedStream(data:Data(data.prefix(received)))
           }
         }
 

--- a/Source/TCPConnection.swift
+++ b/Source/TCPConnection.swift
@@ -51,7 +51,7 @@ public final class TCPConnection: Connection {
     public func send(_ data: Data, timingOut deadline: Double) throws {
         try send(data, flushing: true, timingOut: deadline)
     }
-    
+
     public func send(_ data: Data, flushing flush: Bool, timingOut deadline: Double) throws {
         let socket = try getSocket()
         try ensureStreamIsOpen()
@@ -68,7 +68,7 @@ public final class TCPConnection: Connection {
             try self.flush()
         }
     }
-    
+
     public func flush(timingOut deadline: Double) throws {
         let socket = try getSocket()
         try ensureStreamIsOpen()
@@ -87,7 +87,11 @@ public final class TCPConnection: Connection {
         }
 
         if received == 0 {
+          do {
             try ensureLastOperationSucceeded()
+          } catch SystemError.connectionResetByPeer {
+            throw StreamError.closedStream(data:Data())
+          }
         }
 
         return Data(data.prefix(received))


### PR DESCRIPTION
# fix for

https://github.com/Zewo/Zewo/issues/81#issuecomment-215140403

This is workaround project. It just works with my forks (but only really changed TCP)
(HTTPSClient and TCPSSL changed only for reaching dependency to TCP)
https://www.dropbox.com/s/xeom1s4a0vgffnv/HTTPSClient_issue_fixed.zip?dl=0
@donut this is temporary workaround.
`make build run` on folder 
Maybe you can put your key and id and test it.
# Reason

TCP return reset after finishing SSL request
http://stackoverflow.com/questions/2974021/what-does-econnreset-mean-in-the-context-of-an-af-local-socket
# Workaround

```
          do {
            try ensureLastOperationSucceeded()
          } catch SystemError.connectionResetByPeer {
            throw StreamError.closedStream(data:Data(data.prefix(received)))
          }
```
