### PR TITLE
Added deadline param to initializer

### DIFF
--- a/Source/TCPConnection.swift
+++ b/Source/TCPConnection.swift
@@ -38,8 +38,8 @@ public final class TCPConnection: Connection {
         self.closed = false
     }
 
-    public init(host: String, port: Int) throws {
-        self.ip = try IP(remoteAddress: host, port: port)
+    public init(host: String, port: Int, timingOut deadline: Double = .never) throws {
+        self.ip = try IP(remoteAddress: host, port: port, deadline: deadline)
     }
 
     public func open(timingOut deadline: Double) throws {


### PR DESCRIPTION
Added a deadline to the initializer, because there are low level calls which can hang forever when .never is passed. The default is still .never, but now higher level libs can pass in a valid deadline.

/cc @paulofaria 
