### PR TITLE
Fix TCP socket leak in TCPTLSStream

### DIFF
--- a/Sources/TCP/TCPTLSStream.swift
+++ b/Sources/TCP/TCPTLSStream.swift
@@ -15,7 +15,6 @@ public struct TCPTLSStream : Stream {
     }
 
     public func open(deadline: Double) throws {
-        try tcpStream.open(deadline: deadline)
         try sslStream.open(deadline: deadline)
     }
 


### PR DESCRIPTION
This PR resolves Zewo/Zewo#228.

For every HTTPS connection, two TCP connections were created: one in TCPTLSStream and one in SSLStream; and the first one was left dangling. It seems to be some copy-paste leftover, as SSLStream correctly manages its own connection afterwards.